### PR TITLE
Stop appending px to width and height

### DIFF
--- a/src/VirtualList.svelte
+++ b/src/VirtualList.svelte
@@ -197,10 +197,10 @@
 
 		const totalSize = sizeAndPositionManager.getTotalSize();
 		if (scrollDirection === DIRECTION.VERTICAL) {
-			wrapperStyle = `height:${height}px;width:${width};`;
+			wrapperStyle = `height:${height};width:${width};`;
 			innerStyle = `flex-direction:column;height:${totalSize}px;`;
 		} else {
-			wrapperStyle = `height:${height};width:${width}px`;
+			wrapperStyle = `height:${height};width:${width}`;
 			innerStyle = `min-height:100%;width:${totalSize}px;`;
 		}
 


### PR DESCRIPTION
Allow the width or height, depending on if scrolling horizontally or vertically, to be expressed as a percentage.